### PR TITLE
Allow StampWithIjar to use default shell env

### DIFF
--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -31,6 +31,7 @@ def _stamp_jar(ctx, jar):
             stamped_file.path,
         ],
         mnemonic = "StampWithIjar",
+        use_default_shell_env = True,
     )
 
     return stamped_file


### PR DESCRIPTION
### Description

When action `StampWithIjar` runs it does not allow environment variables to be passed in using `--action_env` command line flag. This can lead to problems when `ijar` is executed on systems that have compiled it with a tool chain picked up from the environment but not available on the host system in standard locations. 

The difference with this change is when `build --action_env=LD_LIBRARY_PATH` or any other `--action_env` env flag is passed it will be threaded into the rules_scala action command environment for `StampWithIjar`.

### Motivation

Tool chains that are picked up from the environment on a host are used to compile native code, but that host does not have proper libc libraries to support execution without knowing `LD_LIBRARY_PATH` where shared libraries exist that do contain symbols compiled against. 
